### PR TITLE
Relocator default dir matches fusee-launcher.py dir

### DIFF
--- a/fusee-launcher.py
+++ b/fusee-launcher.py
@@ -571,7 +571,7 @@ parser.add_argument('-w', dest='wait', action='store_true', help='wait for an RC
 parser.add_argument('-V', metavar='vendor_id', dest='vid', type=parse_usb_id, default=None, help='overrides the TegraRCM vendor ID')
 parser.add_argument('-P', metavar='product_id', dest='pid', type=parse_usb_id, default=None, help='overrides the TegraRCM product ID')
 parser.add_argument('--override-os', metavar='platform', dest='platform', type=str, default=None, help='overrides the detected OS; for advanced users only')
-parser.add_argument('--relocator', metavar='binary', dest='relocator', type=str, default="intermezzo.bin", help='provides the path to the intermezzo relocation stub')
+parser.add_argument('--relocator', metavar='binary', dest='relocator', type=str, default="%s/intermezzo.bin" % os.path.dirname(os.path.abspath(__file__)), help='provides the path to the intermezzo relocation stub')
 parser.add_argument('--override-checks', dest='skip_checks', action='store_true', help="don't check for a supported controller; useful if you've patched your EHCI driver")
 parser.add_argument('--allow-failed-id', dest='permissive_id', action='store_true', help="continue even if reading the device's ID fails; useful for development but not for end users")
 arguments = parser.parse_args()


### PR DESCRIPTION
When trying to run `fusee-launcher.py` from a different directory, I had to also specify `--relocator` even though it lived in the same dir as `fusee-launcher.py`. This just changes the default value for the relocator location to match the directory where `fusee-launcher.py` lives.